### PR TITLE
fix cannot use type [32]uint8 as type []uint8

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -669,5 +669,11 @@ func verifyECDSA(key interface{}, _ crypto.Hash, digest []byte, signature []byte
 // as specified in https://tools.ietf.org/html/rfc7638.
 func JWKThumbprint(jwk string) (string, error) {
 	b := sha256.Sum256([]byte(jwk))
-	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+	var slice []byte
+	if len(b) > 0 {
+		for _, s := range b {
+			slice = append(slice, s)
+		}
+	}
+	return base64.RawURLEncoding.EncodeToString(slice), nil
 }


### PR DESCRIPTION
A proposal to get around the:

```
2021/11/17 07:44:48 traefik.go:81: command traefik error: github.com/team-carepay/traefik-jwt-plugin: failed to import plugin code "github.com/team-carepay/traefik-jwt-plugin": 1:21: import "github.com/team-carepay/traefik-jwt-plugin" error: plugins-local/src/github.com/team-carepay/traefik-jwt-plugin/jwt.go:826:46: cannot use type [32]uint8 as type []uint8
```
raised by Yaegi within Traefik when loading the puglin.