### PR TITLE
Fix/yaegi behaviour while storing several keys in the array

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Supports RSA, ECDSA and symmetric keys. Supports Open Policy Agent (OPA) for add
 
 Features:
 * RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512, HS256, HS384, HS512
-* Certificates or public keys can be configured in the dynamic config 
+* Certificates or public keys can be configured in the dynamic config
 * Supports JWK endpoints for fetching keys remotely
 * Reject a request or Log warning when required field is missing from JWT payload
 * Validate request with Open Policy Agent
@@ -41,10 +41,10 @@ The plugin currently supports the following configuration settings: (all fields 
 
 Name | Description
 --- | ---
-OpaUrl | URL for Open Policy Agent (e.g. http://opa:8181/v1/data/example) 
+OpaUrl | URL for Open Policy Agent (e.g. http://opa:8181/v1/data/example)
 OpaAllowField | Field in the JSON result which contains a boolean, indicating whether the request is allowed or not
 PayloadFields | The field-name in the JWT payload that are required (e.g. `exp`). Multiple field names may be specificied (string array)
-Required | When true, in case the JWT payload is missing a field, the request will be forbidden
+Required | When true, in case there is no or the JWT payload is missing a field, the request will be forbidden
 Keys | Used to validate JWT signature. Multiple keys are supported. Allowed values include certificates, public keys, symmetric keys. In case the value is a valid URL, the plugin will fetch keys from the JWK endpoint.
 Alg | Used to verify which PKI algorithm is used in the JWT
 Iss | Used to verify the issuer of the JWT

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Name | Description
 OpaUrl | URL for Open Policy Agent (e.g. http://opa:8181/v1/data/example)
 OpaAllowField | Field in the JSON result which contains a boolean, indicating whether the request is allowed or not
 PayloadFields | The field-name in the JWT payload that are required (e.g. `exp`). Multiple field names may be specificied (string array)
-Required | When true, in case there is no or the JWT payload is missing a field, the request will be forbidden
+Required | When true, in case the JWT payload is missing a field, the request will be forbidden
 Keys | Used to validate JWT signature. Multiple keys are supported. Allowed values include certificates, public keys, symmetric keys. In case the value is a valid URL, the plugin will fetch keys from the JWK endpoint.
 Alg | Used to verify which PKI algorithm is used in the JWT
 Iss | Used to verify the issuer of the JWT

--- a/jwt.go
+++ b/jwt.go
@@ -377,21 +377,6 @@ func (jwtPlugin *JwtPlugin) CheckToken(request *http.Request) error {
 	if err != nil {
 		return err
 	}
-
-	// JWT token required
-	if jwtToken == nil && (len(jwtPlugin.keys) > 0 || len(jwtPlugin.jwkEndpoints) > 0) {
-		jsonLogEvent, _ := json.Marshal(&LogEvent{
-			Level:   "error",
-			Msg:     fmt.Sprintf("Missing JWT while keys are configured (#keys: %d, #jwkEndpoints: %d)", len(jwtPlugin.keys), len(jwtPlugin.jwkEndpoints)),
-			Time:    time.Now(),
-			Sub:     sub,
-			Network: network,
-			URL:     request.URL.String(),
-		})
-		fmt.Println(string(jsonLogEvent))
-		return fmt.Errorf("Authorization header with JWT Token is required (Authorization: Bearer <JWT>) !!!")
-	}
-
 	if jwtToken != nil {
 		sub = fmt.Sprint(jwtToken.Payload["sub"])
 

--- a/jwt.go
+++ b/jwt.go
@@ -230,7 +230,7 @@ func (jwtPlugin *JwtPlugin) FetchKeys() {
 			// TODO: log warning
 			jsonLogEvent, _ := json.Marshal(&LogEvent{
 				Level: "warning",
-				Msg:   fmt.Sprintf("FetchKeys - Failed to fetch keys"),
+				Msg:   "FetchKeys - Failed to fetch keys",
 				Time:  time.Now(),
 				Sub:   "",
 				URL:   u.String(),
@@ -243,7 +243,7 @@ func (jwtPlugin *JwtPlugin) FetchKeys() {
 			// TODO: log warning
 			jsonLogEvent, _ := json.Marshal(&LogEvent{
 				Level: "warning",
-				Msg:   fmt.Sprintf("FetchKeys - Failed to read keys"),
+				Msg:   "FetchKeys - Failed to read keys",
 				Time:  time.Now(),
 				Sub:   "",
 				URL:   u.String(),
@@ -257,7 +257,7 @@ func (jwtPlugin *JwtPlugin) FetchKeys() {
 			// TODO: log warning
 			jsonLogEvent, _ := json.Marshal(&LogEvent{
 				Level: "warning",
-				Msg:   fmt.Sprintf("FetchKeys - Failed to unmarshall jwksKeys"),
+				Msg:   "FetchKeys - Failed to unmarshall jwksKeys",
 				Time:  time.Now(),
 				Sub:   "",
 				URL:   u.String(),
@@ -460,7 +460,7 @@ func (jwtPlugin *JwtPlugin) ExtractToken(request *http.Request) (*JWT, error) {
 	if len(parts) != 3 {
 		jsonLogEvent, _ := json.Marshal(&LogEvent{
 			Level:   "error",
-			Msg:     fmt.Sprint("Invalid token format"),
+			Msg:     "Invalid token format",
 			Time:    time.Now(),
 			Sub:     "",
 			Network: network,

--- a/jwt.go
+++ b/jwt.go
@@ -24,7 +24,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -40,7 +39,6 @@ type Config struct {
 	Aud           string
 	OpaHeaders    map[string]string
 	JwtHeaders    map[string]string
-	ExpiryCheck   bool
 }
 
 // CreateConfig creates a new OPA Config
@@ -62,7 +60,6 @@ type JwtPlugin struct {
 	aud           string
 	opaHeaders    map[string]string
 	jwtHeaders    map[string]string
-	mu            sync.Mutex
 }
 
 // LogEvent contains a single log entry
@@ -176,9 +173,7 @@ func New(_ context.Context, next http.Handler, config *Config, _ string) (http.H
 
 func (jwtPlugin *JwtPlugin) BackgroundRefresh() {
 	for {
-		jwtPlugin.mu.Lock()
 		jwtPlugin.FetchKeys()
-		jwtPlugin.mu.Unlock()
 		time.Sleep(15 * time.Minute) // 15 min
 	}
 }

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -323,7 +323,7 @@ func TestServeHTTPAllowed(t *testing.T) {
 			t.Fatal("Missing frodo")
 		}
 		bodyContent := input.Input.Body
-		if bodyContent["baggins"] != "shire" {
+		if fmt.Sprintf("%s", bodyContent["baggins"]) != "shire" {
 			t.Fatal("Input body payload incorrect")
 		}
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
A proposal to bypass strange Yaegi behaviours with the array of keys: yaegi is reusing the same address at each iteration -> all array element point to the same address... only the latest value is really kept in the array and then accessible ;-(

Add some logs on CheckToken method to better track where a failure occurs.

Should also allow to execute "yaegi test -v ." without failure.